### PR TITLE
Fix compilation with Intel

### DIFF
--- a/pulsar/system/Space.hpp
+++ b/pulsar/system/Space.hpp
@@ -19,7 +19,7 @@ struct Space{
     ///Angles (radians) of our lattice
     std::array<double,3> lattice_angles;
     ///For your convenience this is the value of infinity
-    constexpr static const double infinity=std::numeric_limits<double>::infinity();
+    static constexpr double infinity=std::numeric_limits<double>::infinity();
     
     ///True if sides are not infinite
     bool is_periodic()const;

--- a/pulsar/system/export.cpp
+++ b/pulsar/system/export.cpp
@@ -238,7 +238,7 @@ void export_system(pybind11::module & m)
 
     // Atom structure
     // Atom class
-    pybind11::class_<Atom>(m, "Atom", pybind11::base<Point>())
+    pybind11::class_<Atom, Point>(m, "Atom")
     .def(pybind11::init<const Atom &>())
     .def_readwrite("Z", &Atom::Z)
     .def_readwrite("isotope", &Atom::isotope)

--- a/test/TestCXX.hpp
+++ b/test/TestCXX.hpp
@@ -12,18 +12,22 @@
 using pulsar::Tester;
 using pulsar::Test_CXX_Base;
 using pulsar::ModuleCreationFuncs;
+
 #define TEST_CLASS(test_name)\
-    class test_name : public Test_CXX_Base {\
-protected:\
-        virtual void run_test_(void);\
-public:\
-    using Test_CXX_Base::Test_CXX_Base;\
-};\
-extern "C" {\
-ModuleCreationFuncs insert_supermodule(void){\
-    ModuleCreationFuncs cf;\
-    cf.add_cpp_creator<test_name>(#test_name);\
-    return cf;\
-}}\
-void test_name::run_test_()
+    class test_name : public Test_CXX_Base\
+    {\
+       protected:\
+         virtual void run_test_(void);\
+       public:\
+         test_name(ID_t id) : Test_CXX_Base(id) { }\
+    };\
+    extern "C" {\
+    ModuleCreationFuncs insert_supermodule(void)\
+    {\
+        ModuleCreationFuncs cf;\
+        cf.add_cpp_creator<test_name>(#test_name);\
+        return cf;\
+    }\
+    }\
+    void test_name::run_test_()
 

--- a/test/modulebase/TestEnergyMethod.cpp
+++ b/test/modulebase/TestEnergyMethod.cpp
@@ -25,7 +25,7 @@ class TestEnergyMethod : public Test_CXX_Base {
 protected:
         virtual void run_test_(void);
 public:
-    using Test_CXX_Base::Test_CXX_Base;
+    TestEnergyMethod(ID_t id) : Test_CXX_Base(id) { }
 };
 
 void TestEnergyMethod::run_test_(){


### PR DESCRIPTION
This fixes a few minor warnings (such as 'static' coming after 'const').
In addition, this implements a workaround for intel compilers where the
compiler would choke with nested constructor forwarding (see
https://software.intel.com/en-us/forums/intel-c-compiler/topic/673768)