### PR TITLE
WIP: Make modules & ModuleManager tolerant of GC

### DIFF
--- a/pulsar/CMakeLists.txt
+++ b/pulsar/CMakeLists.txt
@@ -159,7 +159,7 @@ foreach(sub_dir datastore exception math modulebase modulemanager output
     list(APPEND PULSAR_CORE_FILE_LIST ${PULSAR_${SUB_DIR}_FILES_FULL})
 endforeach()
 
-list(APPEND PULSAR_CORE_FILE_LIST export.cpp)
+list(APPEND PULSAR_CORE_FILE_LIST export.cpp init.cpp)
 
 
 # Actual module library

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import atexit
 import importlib
 
 ##########################################
@@ -69,7 +68,7 @@ def initialize(argv,
 
   # Output depends on MPI being initialized, so we do that first
   set_cmdline(argv)
-  pulsar_core.initialize(nthreads)
+  pulsar_core.parallel_initialize(nthreads)
 
   create_global_output(outpath, outbase, use_stdout)
   enable_color(color)
@@ -79,9 +78,7 @@ def initialize(argv,
 
 
 
-@atexit.register
 def finalize():
   pulsar_core.print_global_output("Finalizing pulsar core\n")
-  pulsar_core.finalize()
-  clear_cmdline()
+  # nothing else to do. All the rest handled in the SO file constructor
 

--- a/pulsar/__init__.py
+++ b/pulsar/__init__.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import atexit
 import importlib
 
 ##########################################
@@ -77,9 +78,10 @@ def initialize(argv,
   gout.enable_debug(debug)
 
 
-def finalize():
-  pulsar_core.print_global_output("Finalizing parallelization\n")
-  pulsar_core.finalize()
 
+@atexit.register
+def finalize():
+  pulsar_core.print_global_output("Finalizing pulsar core\n")
+  pulsar_core.finalize()
   clear_cmdline()
 

--- a/pulsar/init.cpp
+++ b/pulsar/init.cpp
@@ -1,0 +1,30 @@
+/*! \file
+ *
+ * \brief Dynamic library constructor/destructor
+ * \author Benjamin Pritchard (ben@bennyp.org)
+ */ 
+
+
+
+/* These functions get run by the OS when loading or unloading
+ * the shared library. This will happen at the very end, as python
+ * itself is exiting.
+ *
+ * This is better than the atexit python module, since that may
+ * run before final garbage collection and where some variables
+ * may still be in scope
+ */
+
+#include "pulsar/pragma.h"
+#include "pulsar/parallel/Parallel.hpp"
+#include "pulsar/util/Cmdline.hpp"
+
+PULSAR_PLUGIN_CONSTRUCTOR(pulsar_core_initialize_)
+{
+}
+
+PULSAR_PLUGIN_DESTRUCTOR(pulsar_core_finalize_)
+{
+    pulsar::parallel_finalize();
+    pulsar::clear_cmdline();
+}

--- a/pulsar/modulebase/ModuleBase.cpp
+++ b/pulsar/modulebase/ModuleBase.cpp
@@ -35,7 +35,6 @@ ModuleBase::~ModuleBase()
     {
         out.debug("Module [%?] : Output size: %?\n", id(), get_output().size());
         out.debug("Destructed module [%?] : %? v%?\n", id(), name(), version());
-        mlocator_->notify_destruction(id());
     }
 }
 
@@ -148,9 +147,9 @@ CacheData & ModuleBase::cache(void) const noexcept
 // Private functions
 ////////////////////////////////
 
-void ModuleBase::set_module_manager_(ModuleManager * mloc) noexcept
+void ModuleBase::set_module_manager_(std::shared_ptr<ModuleManager> mloc) noexcept
 {
-    mlocator_ = mloc;
+    mlocator_ = std::move(mloc);
 }
 
 void ModuleBase::set_tree_node_(ModuleTreeNode * node) noexcept

--- a/pulsar/modulebase/ModuleBase.hpp
+++ b/pulsar/modulebase/ModuleBase.hpp
@@ -373,7 +373,7 @@ class ModuleBase
         const char * modtype_;
 
         //! The ModuleManager in charge of this module
-        ModuleManager * mlocator_;
+        std::shared_ptr<ModuleManager> mlocator_;
 
         //! My tree node
         ModuleTreeNode * treenode_;
@@ -388,7 +388,7 @@ class ModuleBase
 
         /*! \brief Set the mlocator_ pointer
          */
-        void set_module_manager_(ModuleManager * mloc) noexcept;
+        void set_module_manager_(std::shared_ptr<ModuleManager> mloc) noexcept;
 
 
         /*! \brief Set the tree node pointer

--- a/pulsar/modulemanager/CppSupermoduleLoader.cpp
+++ b/pulsar/modulemanager/CppSupermoduleLoader.cpp
@@ -46,8 +46,10 @@ CppSupermoduleLoader::~CppSupermoduleLoader()
             ffn();
         }
 
-        // close the so
-        dlclose(handle);
+        // We don't close the SO file, since there may be objects
+        // still out which were created from it. They still will be
+        // destructed, although they hopefully won't be used.
+        // dlclose(handle);
 
         print_global_output("Closed supermodule %?\n", it.first);
     }

--- a/pulsar/modulemanager/ModuleManager.hpp
+++ b/pulsar/modulemanager/ModuleManager.hpp
@@ -31,7 +31,7 @@ class Checkpoint;
  * manage the module names and keys, and to create modules via those
  * names and keys.
  */
-class ModuleManager
+class ModuleManager : public std::enable_shared_from_this<ModuleManager>
 {
     public:
         ModuleManager();
@@ -160,9 +160,6 @@ class ModuleManager
          */
         pybind11::object get_module_py(const std::string & modulekey, ID_t parentid);
 
-        /*! \brief Check to see if a module is currently in use
-         */
-        bool module_in_use(ID_t id) const;
 
 
         /*! \brief Change an option for a module
@@ -269,10 +266,6 @@ class ModuleManager
         void enable_debug_all(bool debug) noexcept;
 
 
-        /*! \brief Notify the module manager that a module ID is no longer in use */
-        void notify_destruction(ID_t id);
-
-
         /*! \brief Start syncronizing this module manager's cache
          *         across all ranks
          */
@@ -334,10 +327,6 @@ class ModuleManager
 
         //! The id to assign to the next created module
         std::atomic<ID_t> curid_;
-
-
-        //! Modules currently in use
-        std::set<ID_t> modules_inuse_;
 
 
         /*! \brief All of the cache data */

--- a/pulsar/modulemanager/export.cpp
+++ b/pulsar/modulemanager/export.cpp
@@ -73,7 +73,7 @@ void export_modulemanager(pybind11::module & m)
     //////////////////////////
     // Main ModuleManager
     //////////////////////////
-    pybind11::class_<ModuleManager>(m, "ModuleManager")
+    pybind11::class_<ModuleManager, std::shared_ptr<ModuleManager>>(m, "ModuleManager")
     .def(pybind11::init<>())
     .def("size", &ModuleManager::size)
     .def("module_key_info", &ModuleManager::module_key_info)
@@ -83,7 +83,6 @@ void export_modulemanager(pybind11::module & m)
     .def("generate_unique_key",&ModuleManager::generate_unique_key)
     .def("test_all", &ModuleManager::test_all)
     .def("get_module", &ModuleManager::get_module_py)
-    .def("module_in_use", &ModuleManager::module_in_use)
     .def("change_option", &ModuleManager::change_option_py)
     .def("load_module_from_minfo", &ModuleManager::load_module_from_minfo)
     .def("enable_debug", &ModuleManager::enable_debug)

--- a/pulsar/parallel/Parallel.hpp
+++ b/pulsar/parallel/Parallel.hpp
@@ -27,14 +27,15 @@ const LibTaskForce::HybridEnv& get_env();
  * 
  * \todo Make an overload that takes an MPI_COMM instance
  */
-void initialize(size_t NThreads);
+void parallel_initialize(size_t NThreads);
 
 
 /*! \brief Finalize parallelization functionality
  *
- * This is meant to be called from python
+ * \warning This is never meant to be called from python. Instead,
+ *          it is called by the .so file destructor
  */
-void finalize(void);
+void parallel_finalize(void);
 
 
 /*! \brief Return the ID (rank) associated with this process

--- a/pulsar/parallel/export.cpp
+++ b/pulsar/parallel/export.cpp
@@ -13,8 +13,7 @@ namespace pulsar{
 void export_parallel(pybind11::module & m)
 {
     // Parallelization
-    m.def("initialize", initialize);
-    m.def("finalize", finalize);
+    m.def("parallel_initialize", parallel_initialize);
     m.def("get_proc_id", get_proc_id);
     m.def("get_nproc", get_nproc);
 }

--- a/pulsar/pragma.h
+++ b/pulsar/pragma.h
@@ -56,6 +56,8 @@ extern "C" {
 
 
 
+#define PULSAR_PLUGIN_CONSTRUCTOR(name) void __attribute__ ((constructor)) name(void)
+#define PULSAR_PLUGIN_DESTRUCTOR(name) void __attribute__ ((destructor)) name(void)
 
 
 #ifdef __cplusplus

--- a/pulsar/testing/RunTest.py
+++ b/pulsar/testing/RunTest.py
@@ -59,6 +59,13 @@ print("   test_ext: {}".format(test_ext))
 print("---------------------------------------------------")
 sys.stdout.flush()
 
+# Initialize pulsar
+# From now on, output should go through pulsar
+pulsar.initialize(sys.argv,
+                  color = False,
+                  debug = True,
+                  outbase = "psr_output_" + test_name)
+
 # We can't do the normal import. Some tests may have the
 # same name, which leads to a test_name.py and test_name.so
 # So we have to do it manually, given the full path
@@ -70,11 +77,6 @@ else:
   m = ExtensionFileLoader(test_name, full_path).load_module()
 
 
-# set up pulsar
-pulsar.initialize(sys.argv,
-                  color = False,
-                  debug = True,
-                  outbase = "psr_output_" + test_name)
 
 # Actually run the test, watching for exceptions
 try:
@@ -90,9 +92,6 @@ except Exception as e:
   out.output("\n")
   out.flush()
   ret = -1
-
-# Done with pulsar now
-pulsar.finalize()
 
 # Failure is signaled via non-zero exit value
 exit(ret)

--- a/test/modules/RunTest_BasicModules.py
+++ b/test/modules/RunTest_BasicModules.py
@@ -6,68 +6,65 @@ import pulsar as psr
 thispath = os.path.dirname(os.path.realpath(__file__))
 modpath = os.path.dirname(thispath)
 sys.path.insert(0, modpath)
-print(thispath)
 
-def run_test_inner(tester, ma):
-        ma.load_module("testmodules", "TestCppModule1", "TEST_CPP_MOD1")
-        ma.load_module("testmodules", "TestCppModule2", "TEST_CPP_MOD2")
-        ma.load_module("testmodules", "TestCppModule3", "TEST_CPP_MOD3_c1")
-        ma.load_module("testmodules", "TestCppModule3", "TEST_CPP_MOD3_c2")
-        ma.load_module("testmodules", "TestCppModule3", "TEST_CPP_MOD3_p1")
-        ma.load_module("testmodules", "TestCppModule3", "TEST_CPP_MOD3_p2")
-
-        ma.load_module("testmodules", "TestPyModule1", "TEST_PY_MOD1")
-        ma.load_module("testmodules", "TestPyModule2", "TEST_PY_MOD2")
-        ma.load_module("testmodules", "TestPyModule3", "TEST_PY_MOD3_c1")
-        ma.load_module("testmodules", "TestPyModule3", "TEST_PY_MOD3_c2")
-        ma.load_module("testmodules", "TestPyModule3", "TEST_PY_MOD3_p1")
-        ma.load_module("testmodules", "TestPyModule3", "TEST_PY_MOD3_p2")
-
-        ma.change_option("TEST_CPP_MOD3_c1", "OTHER_MODULE", "TEST_CPP_MOD1")
-        ma.change_option("TEST_CPP_MOD3_c2", "OTHER_MODULE", "TEST_CPP_MOD2")
-        ma.change_option("TEST_CPP_MOD3_p1", "OTHER_MODULE", "TEST_PY_MOD1")
-        ma.change_option("TEST_CPP_MOD3_p2", "OTHER_MODULE", "TEST_PY_MOD2")
-        ma.change_option("TEST_PY_MOD3_c1", "OTHER_MODULE", "TEST_CPP_MOD1")
-        ma.change_option("TEST_PY_MOD3_c2", "OTHER_MODULE", "TEST_CPP_MOD2")
-        ma.change_option("TEST_PY_MOD3_p1", "OTHER_MODULE", "TEST_PY_MOD1")
-        ma.change_option("TEST_PY_MOD3_p2", "OTHER_MODULE", "TEST_PY_MOD2")
-
-        mcpp1 = ma.get_module("TEST_CPP_MOD1", 0)
-        mcpp2 = ma.get_module("TEST_CPP_MOD2", 0)
-        mpy1 = ma.get_module("TEST_PY_MOD1", 0)
-        mpy2 = ma.get_module("TEST_PY_MOD2", 0)
-
-        tester.test_call("Test simple C++ module function", True, mcpp1.run_test)
-        tester.test_call("Test simple Python module function", True, mpy1.run_test)
-        tester.test_call("Test throwing an exception in a C++ module", False, mcpp2.run_test)
-        tester.test_call("Test throwing an exception in a Python module", False, mpy2.run_test)
-
-        mcpp3_c1 = ma.get_module("TEST_CPP_MOD3_c1", 0)
-        mcpp3_c2 = ma.get_module("TEST_CPP_MOD3_c2", 0)
-        mcpp3_p1 = ma.get_module("TEST_CPP_MOD3_p1", 0)
-        mcpp3_p2 = ma.get_module("TEST_CPP_MOD3_p2", 0)
-
-        tester.test_call("C++ calling a C++ module", True, mcpp3_c1.run_test)
-        tester.test_call("C++ calling a C++ module that throws", False, mcpp3_c2.run_test)
-        tester.test_call("C++ calling a Python module", True, mcpp3_p1.run_test)
-        tester.test_call("C++ calling a Python module that throws", False, mcpp3_p2.run_test)
-
-        mpy3_c1 = ma.get_module("TEST_PY_MOD3_c1", 0)
-        mpy3_c2 = ma.get_module("TEST_PY_MOD3_c2", 0)
-        mpy3_p1 = ma.get_module("TEST_PY_MOD3_p1", 0)
-        mpy3_p2 = ma.get_module("TEST_PY_MOD3_p2", 0)
-
-        tester.test_call("Python calling a C++ module", True, mpy3_c1.run_test)
-        tester.test_call("Python calling a C++ module that throws", False, mpy3_c2.run_test)
-        tester.test_call("Python calling a Python module", True, mpy3_p1.run_test)
-        tester.test_call("Python calling a Python module that throws", False, mpy3_p2.run_test)
 
 def run_test():
 
     tester = psr.PyTester("Basic Module Loading/Calling")
 
-    with psr.ModuleAdministrator() as ma:
-        run_test_inner(tester, ma)
+    ma = psr.ModuleAdministrator()
+    ma.load_module("testmodules", "TestCppModule1", "TEST_CPP_MOD1")
+    ma.load_module("testmodules", "TestCppModule2", "TEST_CPP_MOD2")
+    ma.load_module("testmodules", "TestCppModule3", "TEST_CPP_MOD3_c1")
+    ma.load_module("testmodules", "TestCppModule3", "TEST_CPP_MOD3_c2")
+    ma.load_module("testmodules", "TestCppModule3", "TEST_CPP_MOD3_p1")
+    ma.load_module("testmodules", "TestCppModule3", "TEST_CPP_MOD3_p2")
+
+    ma.load_module("testmodules", "TestPyModule1", "TEST_PY_MOD1")
+    ma.load_module("testmodules", "TestPyModule2", "TEST_PY_MOD2")
+    ma.load_module("testmodules", "TestPyModule3", "TEST_PY_MOD3_c1")
+    ma.load_module("testmodules", "TestPyModule3", "TEST_PY_MOD3_c2")
+    ma.load_module("testmodules", "TestPyModule3", "TEST_PY_MOD3_p1")
+    ma.load_module("testmodules", "TestPyModule3", "TEST_PY_MOD3_p2")
+
+    ma.change_option("TEST_CPP_MOD3_c1", "OTHER_MODULE", "TEST_CPP_MOD1")
+    ma.change_option("TEST_CPP_MOD3_c2", "OTHER_MODULE", "TEST_CPP_MOD2")
+    ma.change_option("TEST_CPP_MOD3_p1", "OTHER_MODULE", "TEST_PY_MOD1")
+    ma.change_option("TEST_CPP_MOD3_p2", "OTHER_MODULE", "TEST_PY_MOD2")
+    ma.change_option("TEST_PY_MOD3_c1", "OTHER_MODULE", "TEST_CPP_MOD1")
+    ma.change_option("TEST_PY_MOD3_c2", "OTHER_MODULE", "TEST_CPP_MOD2")
+    ma.change_option("TEST_PY_MOD3_p1", "OTHER_MODULE", "TEST_PY_MOD1")
+    ma.change_option("TEST_PY_MOD3_p2", "OTHER_MODULE", "TEST_PY_MOD2")
+
+    mcpp1 = ma.get_module("TEST_CPP_MOD1", 0)
+    mcpp2 = ma.get_module("TEST_CPP_MOD2", 0)
+    mpy1 = ma.get_module("TEST_PY_MOD1", 0)
+    mpy2 = ma.get_module("TEST_PY_MOD2", 0)
+
+    tester.test_call("Test simple C++ module function", True, mcpp1.run_test)
+    tester.test_call("Test simple Python module function", True, mpy1.run_test)
+    tester.test_call("Test throwing an exception in a C++ module", False, mcpp2.run_test)
+    tester.test_call("Test throwing an exception in a Python module", False, mpy2.run_test)
+
+    mcpp3_c1 = ma.get_module("TEST_CPP_MOD3_c1", 0)
+    mcpp3_c2 = ma.get_module("TEST_CPP_MOD3_c2", 0)
+    mcpp3_p1 = ma.get_module("TEST_CPP_MOD3_p1", 0)
+    mcpp3_p2 = ma.get_module("TEST_CPP_MOD3_p2", 0)
+
+    tester.test_call("C++ calling a C++ module", True, mcpp3_c1.run_test)
+    tester.test_call("C++ calling a C++ module that throws", False, mcpp3_c2.run_test)
+    tester.test_call("C++ calling a Python module", True, mcpp3_p1.run_test)
+    tester.test_call("C++ calling a Python module that throws", False, mcpp3_p2.run_test)
+
+    mpy3_c1 = ma.get_module("TEST_PY_MOD3_c1", 0)
+    mpy3_c2 = ma.get_module("TEST_PY_MOD3_c2", 0)
+    mpy3_p1 = ma.get_module("TEST_PY_MOD3_p1", 0)
+    mpy3_p2 = ma.get_module("TEST_PY_MOD3_p2", 0)
+
+    tester.test_call("Python calling a C++ module", True, mpy3_c1.run_test)
+    tester.test_call("Python calling a C++ module that throws", False, mpy3_c2.run_test)
+    tester.test_call("Python calling a Python module", True, mpy3_p1.run_test)
+    tester.test_call("Python calling a Python module that throws", False, mpy3_p2.run_test)
 
     tester.print_results()
     return tester.nfailed()


### PR DESCRIPTION
This seems to actually work (and is less code...). I just have to ponder the implications a bit, but feel free to try it.

Now each module has a shared_ptr to its ModuleManager. This
ModuleManager will now only be destructed when all modules and all
shared_ptr (via pybind11) are destructed.

In addition, the pulsar finalize() method is now registered to
automatically run at exit and includes a manual GC collection call,
(hopefully) ensuring that all managers, modules, etc, are destructed
prior to finalization.