### PR TITLE
Makes the SystemFragmenter extendable in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Pulsar Computational Chemistry Framework
 
+
 TODO: CI badge and code coverage badge
 
 # Purpose and Overview

--- a/pulsar/datastore/CacheMap_sync.cpp
+++ b/pulsar/datastore/CacheMap_sync.cpp
@@ -58,7 +58,7 @@ int recv_int(int rank, int tag)
 
 void send_str(int rank, int tag, const std::string & s)
 {
-    MPI_Send(s.c_str(), pulsar::numeric_cast<int>(s.size()), MPI_CHAR, rank, tag, 
+    MPI_Send(const_cast<char*>(s.c_str()), pulsar::numeric_cast<int>(s.size()), MPI_CHAR, rank, tag, 
             MPI_COMM_WORLD);
 }
 
@@ -80,7 +80,7 @@ std::string recv_str(int rank, int tag)
 
 void send_data(int rank, int tag, const ByteArray & ba)
 {
-    MPI_Send(ba.data(), pulsar::numeric_cast<int>(ba.size()), MPI_BYTE, rank, tag, MPI_COMM_WORLD);
+    MPI_Send(const_cast<char*>(ba.data()), pulsar::numeric_cast<int>(ba.size()), MPI_BYTE, rank, tag, MPI_COMM_WORLD);
 }
 
 ByteArray recv_data(int rank, int tag)

--- a/pulsar/modulebase/SystemFragmenter.hpp
+++ b/pulsar/modulebase/SystemFragmenter.hpp
@@ -97,7 +97,18 @@ public:
 
     virtual NMerSetType fragmentize_(const System & mol)
     {
-        return call_py_override<NMerSetType>(this, "fragmentize_", mol);
+        using pyNMerSetType=std::map<std::string,NMerInfo>;
+        pyNMerSetType fragset=
+                call_py_override<pyNMerSetType>(this, "fragmentize_", mol);
+        NMerSetType rv;
+        for(auto dict_item: fragset)
+        {
+            std::istringstream iss(dict_item.first);
+            std::set<size_t> new_sn;
+            for(std::string s; iss>>s;)new_sn.insert(atoi(s.c_str()));
+            rv.emplace(std::make_pair(new_sn,dict_item.second));
+        }
+        return rv;
     }
     
     ///Python won't allow sets to be keys so we stringify it

--- a/pulsar/system/ApplyBasisSet.py
+++ b/pulsar/system/ApplyBasisSet.py
@@ -1,14 +1,15 @@
 import os
 import functools
+import pulsar as psr
 
 def transform_name(bsname):
     return bsname.replace("*", "s")
 
 
 def add_shells_to_atom(label, desc, bsmap, atom):
-    atom2 = pulsar.system.Atom(atom)
+    atom2 = psr.Atom(atom)
 
-    binfo = pulsar.system.BasisInfo()
+    binfo = psr.BasisInfo()
     binfo.description = desc
     binfo.shells = bsmap[atom2.Z]
     
@@ -27,20 +28,20 @@ def apply_single_basis(bslabel, bsname, syst):
 
     bspath = None
 
-    for p in pulsar.pulsar_paths["basis"]:
+    for p in psr.pulsar_paths["basis"]:
         testpath = os.path.join(p, transform_name(bsname)) + ".gbs"
         if os.path.isfile(testpath):
             bspath = testpath
             break
           
     if bspath == None:
-        ge = PulsarException("File for basis set does not exist", "bsname", bsname)
-        for p in pulsar.pulsar_paths["basis"]:
+        ge = psr.PulsarException("File for basis set does not exist", "bsname", bsname)
+        for p in psr.pulsar_paths["basis"]:
             ge.append_info("path", p)
         raise ge
 
     # read the map
-    bsmap = BasisSetParsers.read_basis_file(bspath)
+    bsmap = psr.read_basis_file(bspath)
 
     # Apply to all atoms
     f = functools.partial(add_shells_to_atom, bslabel, bsname, bsmap)

--- a/pulsar/system/BasisSetParsers.py
+++ b/pulsar/system/BasisSetParsers.py
@@ -1,4 +1,5 @@
 import re
+import pulsar as psr
 
 # Break apart a list into blocks, where the original list
 # was separated by separator (regex). The first separator is included
@@ -43,7 +44,7 @@ def read_basis_file(path):
                                "file", path, "type", cart)
 
     iscart = (cart == "cartesian")
-    bstype = ShellType.CartesianGaussian if iscart else ShellType.SphericalGaussian
+    bstype = psr.ShellType.CartesianGaussian if iscart else psr.ShellType.SphericalGaussian
 
     atomblocks = block_list(lines[1:], r"\*\*\*\*", True) 
 
@@ -67,20 +68,20 @@ def read_basis_file(path):
             for p in prims:
                 ngen = len(prims[0][1])
                 if len(p[1]) != ngen:
-                    raise PulsarException("Ragged number of general contractions",
+                    raise psr.PulsarException("Ragged number of general contractions",
                                            "element", element, "file", path, "nprim", nprim,
                                            "expected", ngen, "actual", len(p[1]))
 
             # We have all the information to create a shell now
-            amint = string_to_am(am)
-            bsi = BasisShellInfo(bstype, amint, nprim, ngen) 
+            amint = psr.string_to_am(am)
+            bsi = psr.BasisShellInfo(bstype, amint, nprim, ngen)
             for i in range(0, len(prims)):
                 bsi.set_primitive(i, float(prims[i][0]),
                                     [ float(d) for d in prims[i][1] ])
 
             shellvec.append(bsi)
 
-        element_Z = atomic_z_from_symbol(element)
+        element_Z = psr.atomic_z_from_symbol(element)
         basismap[element_Z] = shellvec
                 
  

--- a/test/modulebase/CMakeLists.txt
+++ b/test/modulebase/CMakeLists.txt
@@ -1,1 +1,2 @@
 pulsar_test(modulebase TestNMerInfo)
+pulsar_cxx_test(modulebase TestSystemFragmenter)

--- a/test/modulebase/CMakeLists.txt
+++ b/test/modulebase/CMakeLists.txt
@@ -1,2 +1,2 @@
 pulsar_test(modulebase TestNMerInfo)
-pulsar_cxx_test(modulebase TestSystemFragmenter)
+pulsar_test(modulebase TestSystemFragmenter)

--- a/test/modulebase/TestSystemFragmenter.cpp
+++ b/test/modulebase/TestSystemFragmenter.cpp
@@ -1,0 +1,37 @@
+#include <pulsar/testing/CppTester.hpp>
+#include <pulsar/modulemanager/ModuleManager.hpp>
+#include <pulsar/modulebase/SystemFragmenter.hpp>
+
+
+using namespace std;
+using namespace pulsar;
+
+class TestFragger:public SystemFragmenter{
+public:
+    TestFragger(ID_t id):SystemFragmenter(id){}
+private:
+    NMerSetType fragmentize_(const System& sys){
+        NMerSetType temp({{{0},{{0},sys,1.0}}});
+        return temp;
+    }
+};
+
+TEST_SIMPLE(TestSystemFragmenter){
+    CppTester tester("Testing SystemFragmenter base class");
+
+    ModuleManager mm;
+    mm.load_lambda_module<TestFragger>("TestFragger","Test_fragger");
+
+    auto fragger=mm.get_module<SystemFragmenter>("Test_fragger",0);
+    std::cout<<"hi"<<std::endl;
+    AtomSetUniverse MyU;
+    Atom H=create_atom({0.0,0.0,0.0},1),H1=create_atom({0.0,0.0,0.89},1);
+    MyU.insert(H);
+    MyU.insert(H1);
+    System H2(MyU,true);
+    NMerSetType corr_answer={{{0},{{0},H2,1.0}}};
+    tester.test_member_return("Can call fragmentize",true,corr_answer,
+        &SystemFragmenter::fragmentize,&(*fragger),H2);
+    tester.print_results();
+    return tester.nfailed();
+}

--- a/test/modulebase/TestSystemFragmenter.cpp
+++ b/test/modulebase/TestSystemFragmenter.cpp
@@ -19,11 +19,10 @@ private:
 TEST_SIMPLE(TestSystemFragmenter){
     CppTester tester("Testing SystemFragmenter base class");
 
-    ModuleManager mm;
-    mm.load_lambda_module<TestFragger>("TestFragger","Test_fragger");
+    auto mm=make_shared<ModuleManager>();
+    mm->load_lambda_module<TestFragger>("TestFragger","Test_fragger");
 
-    auto fragger=mm.get_module<SystemFragmenter>("Test_fragger",0);
-    std::cout<<"hi"<<std::endl;
+    auto fragger=mm->get_module<SystemFragmenter>("Test_fragger",0);
     AtomSetUniverse MyU;
     Atom H=create_atom({0.0,0.0,0.0},1),H1=create_atom({0.0,0.0,0.89},1);
     MyU.insert(H);

--- a/test/modulebase/TestSystemFragmenter.py
+++ b/test/modulebase/TestSystemFragmenter.py
@@ -1,0 +1,33 @@
+import pulsar as psr
+
+
+
+class TestFragger(psr.SystemFragmenter):
+    def __init__(self,id):
+        super(TestFragger,self).__init__(id)
+
+    def fragmentize_(self,sys):
+        nsi=psr.NMerInfo()
+        nsi.sn={0,}
+        nsi.nmer=sys
+        nsi.weight=1.0
+        return {"0 ":nsi}
+
+def run_test():
+    tester=psr.PyTester("Testing SystemFragmenter Python Bindings")
+    mm=psr.ModuleManager()
+    mm.load_lambda_module(TestFragger,"TestFragger","Test_fragger")
+    fragger=mm.get_module("Test_fragger",0)
+    sys=psr.make_system("""
+    H 0.0 0.0 0.0
+    H 0.0 0.0 0.89
+    """)
+    corr_answer=psr.NMerInfo()
+    corr_answer.sn={0,}
+    corr_answer.nmer=sys
+    corr_answer.weight=1.0
+    print(fragger.fragmentize(sys))
+    tester.test_return("Can call fragmentize",True,{"0 ":corr_answer},
+        fragger.fragmentize,sys)
+    tester.print_results()
+    return tester.nfailed()


### PR DESCRIPTION
At the moment the `SystemFragmenter` defines the member function `fragmentize_`, which is to be overloaded by the derived class.  For better or for worse, the return value of this function is `std::map<std::set<size_t>,pulsar::NMerTypeInfo>`.  This poses a problem in Python as Python's set class
can't be used as a key type because it is mutable.  The usual Python fix of "use a tuple" doesn't work C-side because we won't know the length of the tuple ahead of time.  Consequentially, I somewhat punted and made it so Py-side the set is replaced with a string *e.g.* the set `{1,2,3}` would become `"1 2 3"`.

This all works well and good unitl you try to extend the `SystemFragmenter` base class in Python, then you try to return a dictionary of strings mapped to `NMerTypeInfo` and Pybind11 can't convert it to a map of sets to `NMerTypeInfo`.  This PR mainly fixes that by adding a bit of parsing to the Python export.

- [x] Fixes the basis set parsing scripts (still used namespaces like `system`)
- [x] Make `SystemFragmenter` extendable
- [x] Add unit tests