### PR TITLE
One electron prop

### DIFF
--- a/pulsar/modulebase/PropertyCalculator.hpp
+++ b/pulsar/modulebase/PropertyCalculator.hpp
@@ -13,7 +13,7 @@
 
 namespace pulsar{
 
-/*! \brief One-electron integral implementation
+/*! \brief One-electron property
  *
  */
 class PropertyCalculator : public ModuleBase
@@ -30,12 +30,10 @@ class PropertyCalculator : public ModuleBase
          *
          */
         std::vector<double> calculate(unsigned int deriv,
-                                      const Wavefunction & wfn,
-                                      const BasisSet & bs1,
-                                      const BasisSet & bs2)
+                                      const Wavefunction & wfn)
         {
             return ModuleBase::call_function(&PropertyCalculator::calculate_,
-                                                deriv, wfn, bs1, bs2);
+                                                deriv, wfn);
         }
 
 
@@ -44,9 +42,7 @@ class PropertyCalculator : public ModuleBase
         /////////////////////////////////////////
         //! \copydoc calculate
         virtual std::vector<double> calculate_(unsigned int deriv,
-                                               const Wavefunction & wfn,
-                                               const BasisSet & bs1,
-                                               const BasisSet & bs2) = 0;
+                                               const Wavefunction & wfn) = 0;
 };
 
 
@@ -58,11 +54,9 @@ class PropertyCalculator_Py : public PropertyCalculator
         MODULEBASE_FORWARD_PROTECTED_TO_PY
 
         virtual std::vector<double> calculate_(unsigned int deriv,
-                                               const Wavefunction & wfn,
-                                               const BasisSet & bs1,
-                                               const BasisSet & bs2)
+                                               const Wavefunction & wfn)
         {
-            return call_py_override<std::vector<double>>(this, "calculate_", wfn, deriv, bs1, bs2);
+            return call_py_override<std::vector<double>>(this, "calculate_", wfn, deriv);
         }
 };
 

--- a/pulsar/system/Atom.hpp
+++ b/pulsar/system/Atom.hpp
@@ -133,7 +133,8 @@ std::ostream& operator<<(std::ostream& os,const Atom& A);
 
 
 
-/* \brief Create an atom given an ID, coordinates, and atomic number
+/* \relates Atom
+ * \brief Create an atom given an ID, coordinates, and atomic number
  *
  * The rest of the data is filled in automatically
  */
@@ -145,7 +146,8 @@ Atom create_atom(CoordType xyz, int Z);
 
 
 
-/* \brief Create an atom given an ID, coordinates, atomic number, and isotope number
+/* \relates Atom
+ * \brief Create an atom given an ID, coordinates, atomic number, and isotope number
  *
  * The rest of the data is filled in automatically
  */


### PR DESCRIPTION
This is a small change to the PropertyCalculator API that removes the basis sets.  I admittedly may not have remembered what this class did correctly, but I thought it was supposed to compute properties given a wavefunction (charges, esp, etc.).