### PR TITLE
Better integral handling from Python

### DIFF
--- a/pulsar/math/EigenImpl.hpp
+++ b/pulsar/math/EigenImpl.hpp
@@ -157,7 +157,7 @@ class EigenTensorImpl : public TensorImpl<rank,double>
         ///True if the underlying Eigen matrices are the same
         bool operator==(const EigenTensorImpl<rank>& rhs)const
         {
-            return mat_==mat_;
+            return mat_==rhs.mat_;
         }
 
         ///True if the underlying Eigen matrices are not the same
@@ -222,7 +222,7 @@ class EigenTensorImpl : public TensorImpl<rank,double>
             archive(cereal::base_class<TensorImpl<rank,double>>(this));
         }
 
-        void hash(bphash::Hasher & h) const
+        void hash(bphash::Hasher &) const
         {
            // h(*mat_);
         }

--- a/pulsar/modulebase/FourCenterIntegral.hpp
+++ b/pulsar/modulebase/FourCenterIntegral.hpp
@@ -10,7 +10,7 @@
 
 #include "pulsar/modulebase/ModuleBase.hpp"
 #include "pulsar/system/BasisSet.hpp"
-
+#include "pulsar/util/PythonIntegralHelper.hpp"
 
 namespace pulsar{
 
@@ -19,7 +19,11 @@ namespace pulsar{
  */
 class FourCenterIntegral : public ModuleBase
 {
-    public:
+protected:
+    PythonIntegralHelper helper_;
+
+
+public:
         typedef FourCenterIntegral BaseType;
         typedef std::string HashType;
 
@@ -46,8 +50,9 @@ class FourCenterIntegral : public ModuleBase
         {
             ModuleBase::call_function(&FourCenterIntegral::uninitialized_or_throw_);
             ModuleBase::call_function(&FourCenterIntegral::initialize_, deriv, wfn, bs1, bs2, bs3, bs4);
+            helper_.initialize(bs1,bs2,bs3,bs4);
             initialized_ = true;
-        }
+        }       
 
         HashType my_hash(unsigned int deriv,
                         const Wavefunction & wfn,
@@ -69,7 +74,6 @@ class FourCenterIntegral : public ModuleBase
             return ModuleBase::call_function(&FourCenterIntegral::n_components_);
         }
 
-
         /*! \brief calculate an integral
          *
          * \param [in] shell1 Shell index on the first center
@@ -87,25 +91,6 @@ class FourCenterIntegral : public ModuleBase
             return ModuleBase::call_function(&FourCenterIntegral::calculate_,
                                                 shell1, shell2, shell3, shell4);
         }
-
-        /*! \brief calculate an integral (for use from python)
-         *
-         * \param [in] shell1 Shell index on the first center
-         * \param [in] shell2 Shell index on the second center
-         * \param [in] shell3 Shell index on the third center
-         * \param [in] shell4 Shell index on the fourth center
-         * \param [in] outbuffer Where to place the completed integrals
-         * \return Number of integrals calculated
-         */
-        pybind11::memoryview calculate_py(uint64_t shell1, uint64_t shell2,
-                                          uint64_t shell3, uint64_t shell4)
-        {
-               const double* ints =
-                ModuleBase::call_function(&FourCenterIntegral::calculate_,
-                                              shell1, shell2, shell3,shell4);
-               return memoryview_cast(ints,10000);
-        }
-
 
         /*! \brief calculate multiple integrals
          *
@@ -127,6 +112,23 @@ class FourCenterIntegral : public ModuleBase
                                                   shells1, shells2, shells3, shells4);
         }
 
+        /*! \brief calculate an integral (for use from python)
+         *
+         * \param [in] shell1 Shell index on the first center
+         * \param [in] shell2 Shell index on the second center
+         * \param [in] shell3 Shell index on the third center
+         * \param [in] shell4 Shell index on the fourth center
+         * \return Integrals in a Python list
+         */
+        pybind11::list calculate_py(uint64_t shell1, uint64_t shell2,
+                                          uint64_t shell3, uint64_t shell4)
+        {
+               const double* ints =
+                ModuleBase::call_function(&FourCenterIntegral::calculate_,
+                                              shell1, shell2, shell3,shell4);
+               return helper_.int_2_py(ints,shell1,shell2,shell3,shell4);
+        }
+
 
         /*! \brief calculate multiple integrals (for use from python)
          *
@@ -134,20 +136,17 @@ class FourCenterIntegral : public ModuleBase
          * \param [in] shells2 Shell indicies on the second center
          * \param [in] shells3 Shell indicies on the third center
          * \param [in] shells4 Shell indicies on the fourth center
-         * \param [in] outbuffer Where to place the completed integrals
-         * \return Number of integrals calculated
+         * \return The integrals in a Python list
          */
-        const double* calculate_multi_py(const std::vector<uint64_t> & shells1,
+        pybind11::list calculate_multi_py(const std::vector<uint64_t> & shells1,
                                     const std::vector<uint64_t> & shells2,
                                     const std::vector<uint64_t> & shells3,
-                                    const std::vector<uint64_t> & shells4,
-                                    pybind11::buffer outbuffer)
+                                    const std::vector<uint64_t> & shells4)
         {
-            //auto ptrinfo = python_buffer_to_ptr<double>(outbuffer, 1);
-
-            //return ModuleBase::call_function(&FourCenterIntegral::calculate_multi_,
-            //                                    shells1, shells2, shells3, shells4,
-            //                                    ptrinfo.first, ptrinfo.second[0]);
+            const double* ints=
+              ModuleBase::call_function(&FourCenterIntegral::calculate_multi_,
+                                           shells1, shells2, shells3, shells4);
+            return helper_.multi_int_2_py(ints,shells1,shells2,shells3,shells4);
         }
 
 
@@ -181,31 +180,31 @@ class FourCenterIntegral : public ModuleBase
                                     uint64_t shell3, uint64_t shell4) = 0;
 
         //! \copydoc calculate_multi
-        virtual const double* calculate_multi_(const std::vector<uint64_t> & shells1,
-                                          const std::vector<uint64_t> & shells2,
-                                          const std::vector<uint64_t> & shells3,
-                                          const std::vector<uint64_t> & shells4)
+        virtual const double* calculate_multi_(const std::vector<uint64_t> & /*shells1*/,
+                                          const std::vector<uint64_t> & /*shells2*/,
+                                          const std::vector<uint64_t> & /*shells3*/,
+                                          const std::vector<uint64_t> & /*shells4*/)
         {
-            //////////////////////////////////////////////////////////
-            // default implementation - just loop over and do them all
-            //////////////////////////////////////////////////////////
+//            //////////////////////////////////////////////////////////
+//            // default implementation - just loop over and do them all
+//            //////////////////////////////////////////////////////////
 
-            /*uint64_t ntotal = 0;
+//            uint64_t ntotal = 0;
 
-            for(uint64_t s1 : shells1)
-            for(uint64_t s2 : shells2)
-            for(uint64_t s3 : shells3)
-            for(uint64_t s4 : shells4)
-            {
-                uint64_t nbatch = calculate_(s1, s2, s3, s4);
-                ntotal += nbatch;
-                outbuffer += nbatch;
+//            for(uint64_t s1 : shells1)
+//            for(uint64_t s2 : shells2)
+//            for(uint64_t s3 : shells3)
+//            for(uint64_t s4 : shells4)
+//            {
+//                uint64_t nbatch = calculate_(s1, s2, s3, s4);
+//                ntotal += nbatch;
+//                outbuffer += nbatch;
 
-                // be safe with unsigned types
-                bufsize = ( (nbatch >= bufsize) ? 0 : (bufsize - nbatch) );
-            }
+//                // be safe with unsigned types
+//                bufsize = ( (nbatch >= bufsize) ? 0 : (bufsize - nbatch) );
+//            }
 
-            return ntotal;*/
+            return nullptr;
         }
 
 
@@ -230,7 +229,7 @@ class FourCenterIntegral : public ModuleBase
 
 class FourCenterIntegral_Py : public FourCenterIntegral
 {
-    public:
+     public:
         using FourCenterIntegral::FourCenterIntegral;
 
         MODULEBASE_FORWARD_PROTECTED_TO_PY
@@ -269,10 +268,10 @@ class FourCenterIntegral_Py : public FourCenterIntegral
         virtual const double* calculate_(uint64_t shell1, uint64_t shell2,
                                     uint64_t shell3, uint64_t shell4)
         {
-                pybind11::buffer_info info =
-                    call_py_override<pybind11::buffer>(this,"calculate_",shell1,shell2,shell3,shell4).request();
+                pybind11::list ints =
+                    call_py_override<pybind11::list>(this,"calculate_",shell1,shell2,shell3,shell4);
 
-                return static_cast<const double*>(info.ptr);
+                return helper_.py_2_int(ints);
         }
 
 
@@ -282,22 +281,14 @@ class FourCenterIntegral_Py : public FourCenterIntegral
                                           const std::vector<uint64_t> & shells4)
         {
 
-//            if(has_py_override<FourCenterIntegral>(this, "calculate_multi_"))
-//            {
-//                //! \todo untested
+              if(has_py_override<FourCenterIntegral>(this, "calculate_multi_"))
+              {
+                  pybind11::list ints=
+                          call_py_override<pybind11::list>(this,"calculate_multi_",shells1,shells2,shells3,shells4);
+                  return helper_.py_2_int(ints);
+              }
 
-//                pybind11::buffer_info pybuf(outbuffer,
-//                                            sizeof(double),
-//                                            pybind11::format_descriptor<double>::format(),
-//                                            1, { bufsize },
-//                                            { sizeof(double) });
-
-//                return call_py_override<uint64_t>(this, "calculate_multi_",
-//                                                shells1, shells2, shells3, shells4, pybuf, bufsize);
-//            }
-//            else
-//                return FourCenterIntegral::calculate_multi_(shells1, shells2, shells3, shells4,
-//                                                                outbuffer, bufsize);
+              return FourCenterIntegral::calculate_multi_(shells1, shells2, shells3, shells4);
         }
 
 };

--- a/pulsar/modulebase/ThreeCenterIntegral.hpp
+++ b/pulsar/modulebase/ThreeCenterIntegral.hpp
@@ -8,6 +8,7 @@
 
 #include "pulsar/modulebase/ModuleBase.hpp"
 #include "pulsar/system/BasisSet.hpp"
+#include "pulsar/util/PythonIntegralHelper.hpp"
 
 
 namespace pulsar{
@@ -17,6 +18,8 @@ namespace pulsar{
  */
 class ThreeCenterIntegral : public ModuleBase
 {
+protected:
+    PythonIntegralHelper helper_;
     public:
         typedef ThreeCenterIntegral BaseType;
         typedef std::string HashType;
@@ -41,6 +44,7 @@ class ThreeCenterIntegral : public ModuleBase
         {
             ModuleBase::call_function(&ThreeCenterIntegral::uninitialized_or_throw_);
             ModuleBase::call_function(&ThreeCenterIntegral::initialize_, deriv, wfn, bs1, bs2, bs3);
+            helper_.initialize(bs1,bs2,bs3);
             initialized_ = true;
         }
 
@@ -80,22 +84,6 @@ class ThreeCenterIntegral : public ModuleBase
                                                 shell1, shell2, shell3);
         }
 
-        /*! \brief calculate an integral (for use from python)
-         *
-         * \param [in] shell1 Shell index on the first center
-         * \param [in] shell2 Shell index on the second center
-         * \param [in] shell3 Shell index on the third center
-         * \return The integral buffer
-         */
-         pybind11::memoryview calculate_py(uint64_t shell1, uint64_t shell2, uint64_t shell3)
-         {
-                const double* ints =
-                 ModuleBase::call_function(&ThreeCenterIntegral::calculate_,
-                                               shell1, shell2, shell3);
-                return memoryview_cast(ints,10000);
-         }
-
-
         /*! \brief calculate multiple integrals
          *
          * \param [in] shells1 Shell indicies on the first center
@@ -115,24 +103,37 @@ class ThreeCenterIntegral : public ModuleBase
         }
 
 
+        /*! \brief calculate an integral (for use from python)
+         *
+         * \param [in] shell1 Shell index on the first center
+         * \param [in] shell2 Shell index on the second center
+         * \param [in] shell3 Shell index on the third center
+         * \return Integrals in a Python list
+         */
+        pybind11::list calculate_py(uint64_t shell1, uint64_t shell2,uint64_t shell3)
+        {
+               const double* ints =
+                ModuleBase::call_function(&ThreeCenterIntegral::calculate_,
+                                              shell1, shell2, shell3);
+               return helper_.int_2_py(ints,shell1,shell2,shell3);
+        }
+
+
         /*! \brief calculate multiple integrals (for use from python)
          *
          * \param [in] shells1 Shell indicies on the first center
          * \param [in] shells2 Shell indicies on the second center
          * \param [in] shells3 Shell indicies on the third center
-         * \param [in] outbuffer Where to place the completed integrals
-         * \return Number of integrals calculated
+         * \return The integrals in a Python list
          */
-        const double* calculate_multi_py(const std::vector<uint64_t> & shells1,
+        pybind11::list calculate_multi_py(const std::vector<uint64_t> & shells1,
                                     const std::vector<uint64_t> & shells2,
-                                    const std::vector<uint64_t> & shells3,
-                                    pybind11::buffer outbuffer)
+                                    const std::vector<uint64_t> & shells3)
         {
-            //auto ptrinfo = python_buffer_to_ptr<double>(outbuffer, 1);
-
-            //return ModuleBase::call_function(&ThreeCenterIntegral::calculate_multi_,
-            //                                    shells1, shells2, shells3, shells4,
-            //                                    ptrinfo.first, ptrinfo.second[0]);
+            const double* ints=
+              ModuleBase::call_function(&ThreeCenterIntegral::calculate_multi_,
+                                           shells1, shells2, shells3);
+            return helper_.multi_int_2_py(ints,shells1,shells2,shells3);
         }
 
 
@@ -164,30 +165,30 @@ class ThreeCenterIntegral : public ModuleBase
                                     uint64_t shell3) = 0;
 
         //! \copydoc calculate_multi
-        virtual const double* calculate_multi_(const std::vector<uint64_t> & shells1,
-                                          const std::vector<uint64_t> & shells2,
-                                          const std::vector<uint64_t> & shells3)
+        virtual const double* calculate_multi_(const std::vector<uint64_t> & /*shells1*/,
+                                          const std::vector<uint64_t> & /*shells2*/,
+                                          const std::vector<uint64_t> & /*shells3*/)
         {
-            //////////////////////////////////////////////////////////
-            // default implementation - just loop over and do them all
-            //////////////////////////////////////////////////////////
+//            //////////////////////////////////////////////////////////
+//            // default implementation - just loop over and do them all
+//            //////////////////////////////////////////////////////////
 
-            /*uint64_t ntotal = 0;
+//            uint64_t ntotal = 0;
 
-            for(uint64_t s1 : shells1)
-            for(uint64_t s2 : shells2)
-            for(uint64_t s3 : shells3)
-            for(uint64_t s4 : shells4)
-            {
-                uint64_t nbatch = calculate_(s1, s2, s3, s4);
-                ntotal += nbatch;
-                outbuffer += nbatch;
+//            for(uint64_t s1 : shells1)
+//            for(uint64_t s2 : shells2)
+//            for(uint64_t s3 : shells3)
+//            for(uint64_t s4 : shells4)
+//            {
+//                uint64_t nbatch = calculate_(s1, s2, s3, s4);
+//                ntotal += nbatch;
+//                outbuffer += nbatch;
 
-                // be safe with unsigned types
-                bufsize = ( (nbatch >= bufsize) ? 0 : (bufsize - nbatch) );
-            }
+//                // be safe with unsigned types
+//                bufsize = ( (nbatch >= bufsize) ? 0 : (bufsize - nbatch) );
+//            }
 
-            return ntotal;*/
+            return nullptr;
         }
 
 
@@ -236,15 +237,6 @@ class ThreeCenterIntegral_Py : public ThreeCenterIntegral
                 return ThreeCenterIntegral::n_components_();
         }
 
-
-        virtual const double* calculate_(uint64_t shell1, uint64_t shell2, uint64_t shell3)
-        {
-            pybind11::buffer_info info =
-                call_py_override<pybind11::buffer>(this,"calculate_",shell1,shell2,shell3).request();
-
-            return static_cast<const double*>(info.ptr);
-        }
-
         virtual HashType my_hash_(unsigned int deriv,
                                   const Wavefunction &wfn,
                                   const BasisSet &bs1,
@@ -253,27 +245,29 @@ class ThreeCenterIntegral_Py : public ThreeCenterIntegral
         {
             return call_py_override<HashType>(this,"my_hash_", deriv, wfn,bs1, bs2,bs3);
         }
+        virtual const double* calculate_(uint64_t shell1, uint64_t shell2,
+                                    uint64_t shell3)
+        {
+                pybind11::list ints =
+                    call_py_override<pybind11::list>(this,"calculate_",shell1,shell2,shell3);
+
+                return helper_.py_2_int(ints);
+        }
+
+
         virtual const double* calculate_multi_(const std::vector<uint64_t> & shells1,
                                           const std::vector<uint64_t> & shells2,
                                           const std::vector<uint64_t> & shells3)
         {
 
-//            if(has_py_override<ThreeCenterIntegral>(this, "calculate_multi_"))
-//            {
-//                //! \todo untested
+              if(has_py_override<ThreeCenterIntegral>(this, "calculate_multi_"))
+              {
+                  pybind11::list ints=
+                          call_py_override<pybind11::list>(this,"calculate_multi_",shells1,shells2,shells3);
+                  return helper_.py_2_int(ints);
+              }
 
-//                pybind11::buffer_info pybuf(outbuffer,
-//                                            sizeof(double),
-//                                            pybind11::format_descriptor<double>::format(),
-//                                            1, { bufsize },
-//                                            { sizeof(double) });
-
-//                return call_py_override<uint64_t>(this, "calculate_multi_",
-//                                                shells1, shells2, shells3, shells4, pybuf, bufsize);
-//            }
-//            else
-//                return ThreeCenterIntegral::calculate_multi_(shells1, shells2, shells3, shells4,
-//                                                                outbuffer, bufsize);
+              return ThreeCenterIntegral::calculate_multi_(shells1, shells2, shells3);
         }
 
 };

--- a/pulsar/util/PythonIntegralHelper.hpp
+++ b/pulsar/util/PythonIntegralHelper.hpp
@@ -1,0 +1,71 @@
+#pragma once
+#include "pulsar/system/BasisSet.hpp"
+
+
+namespace pulsar{
+
+/*! \brief Pulsar side code factorization to accomodate Python API to
+ *  integrals
+ *
+ */
+class PythonIntegralHelper
+{
+protected:
+    std::vector<BasisSet> bs_;
+    std::vector<double> buffer_;
+public:
+        /*! \brief initialize the basis sets
+         *
+         */
+        template<typename...Args>
+        void initialize(Args...args)
+        {
+            bs_=std::vector<BasisSet>({args...});
+        }
+
+        ///Returns the number of basis functions in the current shell n-tuple
+        template<typename...Args>
+        size_t size(Args...args)const{
+            std::vector<size_t> shells({args...});
+            size_t total=1;
+            for(size_t i=0;i<shells.size();++i)
+                total*=bs_[i].shell(shells[i]).n_functions();
+            return total;
+        }
+
+        size_t size(const std::vector<std::vector<size_t>>& shells)const{
+            size_t n_funcs=1;
+            for(size_t i=0;i<shells[0].size();++i)//Assume vectors of same size
+                for(size_t j=0;j<shells.size();++j)
+                    n_funcs*=bs_[j].shell(shells[j][i]).n_functions();
+            return n_funcs;
+        }
+
+        template<typename...Args>
+        pybind11::list int_2_py(const double* ints,Args...args)const
+        {
+            pybind11::list rv;
+            for(size_t i=0;i<size(args...);++i)
+                   rv.append(ints[i]);
+            return rv;
+        }
+
+        template<typename...Args>
+        pybind11::list multi_int_2_py(const double* ints,Args...args)const
+        {
+            pybind11::list rv;
+            std::vector<std::vector<size_t>> shells({args...});
+            for(size_t i=0;i<size(shells);++i)
+                    rv.append(ints[i]);
+            return rv;
+        }
+
+        const double* py_2_int(pybind11::list& ints)
+        {
+            buffer_=std::vector<double>(ints.size());
+            for(size_t i=0;i<ints.size();++i)
+                buffer_[i]=ints[i].cast<double>();
+            return buffer_.data();
+        }
+};
+}

--- a/test/modulebase/TestFourCenterIntegral.py
+++ b/test/modulebase/TestFourCenterIntegral.py
@@ -1,7 +1,7 @@
 import pulsar as psr
 import numpy as np
 
-Mat1 = np.array([1.1,2.2,3.3])
+Mat1 = [1.1,2.2,3.3]
 
 class Test4CInt(psr.FourCenterIntegral):
     def __init__(self,id):
@@ -23,9 +23,11 @@ def run_test():
     builder=mm.get_module("test_builder",0)
     deriv=1
     wf=psr.Wavefunction()
-    bs=psr.BasisSet(1,3,3,3)
+    bs=psr.BasisSet(1,1,1,3)
+    bs.add_shell(psr.BasisShellInfo(psr.ShellType.SphericalGaussian,0,1,1,[0.0],[0.0]),
+                 [0.0,0.0,0.0])
     tester.test_call("Can call initialize",True,builder.initialize,deriv,wf,bs,bs,bs,bs)
-    temp = builder.calculate(deriv,deriv,deriv,deriv).tolist()
+    temp = builder.calculate(0,0,0,0)
     tester.test_double_vector("Can call calculate",Mat1,temp)
 
     tester.print_results()

--- a/test/modulebase/TestThreeCenterIntegral.py
+++ b/test/modulebase/TestThreeCenterIntegral.py
@@ -1,7 +1,7 @@
 import pulsar as psr
 import numpy as np
 
-Mat1 = np.array([1.1,2.2,3.3])
+Mat1 = [1.1,2.2,3.3]
 
 class Test3CInt(psr.ThreeCenterIntegral):
     def __init__(self,id):
@@ -23,9 +23,11 @@ def run_test():
     builder=mm.get_module("test_builder",0)
     deriv=1
     wf=psr.Wavefunction()
-    bs=psr.BasisSet(1,3,3,3)
+    bs=psr.BasisSet(1,1,1,3)
+    bs.add_shell(psr.BasisShellInfo(psr.ShellType.SphericalGaussian,0,1,1,[0.0],[0.0]),
+                 [0.0,0.0,0.0])
     tester.test_call("Can call initialize",True,builder.initialize,deriv,wf,bs,bs,bs)
-    temp = builder.calculate(deriv,deriv,deriv).tolist()
+    temp = builder.calculate(0,0,0)
     tester.test_double_vector("Can call calculate",Mat1,temp)
 
     tester.print_results()

--- a/test/modulebase/TestTwoCenterIntegral.py
+++ b/test/modulebase/TestTwoCenterIntegral.py
@@ -1,7 +1,7 @@
 import pulsar as psr
 import numpy as np
 
-Mat1 = np.array([1.1,2.2,3.3])
+Mat1 = [1.1,2.2,3.3]
 
 class Test2CInt(psr.TwoCenterIntegral):
     def __init__(self,id):
@@ -23,9 +23,11 @@ def run_test():
     builder=mm.get_module("test_builder",0)
     deriv=1
     wf=psr.Wavefunction()
-    bs=psr.BasisSet(1,3,3,3)
+    bs=psr.BasisSet(1,1,1,3)
+    bs.add_shell(psr.BasisShellInfo(psr.ShellType.SphericalGaussian,0,1,1,[0.0],[0.0]),
+                 [0.0,0.0,0.0])
     tester.test_call("Can call initialize",True,builder.initialize,deriv,wf,bs,bs)
-    temp = builder.calculate(deriv,deriv).tolist()
+    temp = builder.calculate(0,0)
     tester.test_double_vector("Can call calculate",Mat1,temp)
 
     tester.print_results()


### PR DESCRIPTION
Despite the title of this branch I didn't actually revert the integrals.  I set out with every intent of doing that, but....long story short, our only current user base wants to use LibInt and I think it's in our interest to support it and its non-canonical API rather than giving them a product that is incapable of production level code without modifying LibInt.  The current interface should also work with SimInt if the `double*` it passes is moved to a member.  

On the Python side, I added a `PythonIntegralHelper` class which basically takes the `double *` and wraps it up into a Python list.  I decided that if you're digesting integrals in Python you can afford a copy.  The C++ performance should be unaffected (aside from the basis sets are copied in the initialize function, if this is really an issue we can just store const pointers to the basis sets).